### PR TITLE
FI-920 add optional mergeExtensions option

### DIFF
--- a/src/PatchResolver.js
+++ b/src/PatchResolver.js
@@ -35,8 +35,9 @@ function mergeErrors(previousErrors, patchErrors) {
     return undefined;
 }
 
-export function PatchResolver({ onResponse }) {
+export function PatchResolver({ onResponse, mergeExtensions = () => {} }) {
     this.onResponse = onResponse;
+    this.mergeExtensions = mergeExtensions;
     this.previousResponse = null;
     this.processedChunks = 0;
     this.chunkBuffer = '';
@@ -58,10 +59,7 @@ PatchResolver.prototype.handleChunk = function(data) {
                     ...this.previousResponse,
                     data: applyPatch(this.previousResponse.data, part.path, part.data),
                     errors: mergeErrors(this.previousResponse.errors, part.errors),
-                    extensions: {
-                        ...this.previousResponse.extensions,
-                        ...path.extensions,
-                    }
+                    extensions: this.mergeExtensions(this.previousResponse.extensions, part.extensions),
                 };
             }
             this.processedChunks += 1;

--- a/src/PatchResolver.js
+++ b/src/PatchResolver.js
@@ -58,6 +58,10 @@ PatchResolver.prototype.handleChunk = function(data) {
                     ...this.previousResponse,
                     data: applyPatch(this.previousResponse.data, part.path, part.data),
                     errors: mergeErrors(this.previousResponse.errors, part.errors),
+                    extensions: {
+                        ...this.previousResponse.extensions,
+                        ...path.extensions,
+                    }
                 };
             }
             this.processedChunks += 1;


### PR DESCRIPTION
I got response times to work locally for deferred queries (very hackily). I need to change `apollo-server-core` (in a not hacky way) and re-publish to get this to work properly; however, this is a part of the solution.