### PR TITLE
Optionally disable incremental responses

### DIFF
--- a/src/__test__/PatchResolver.spec.js
+++ b/src/__test__/PatchResolver.spec.js
@@ -183,4 +183,21 @@ describe('PathResolver', function() {
         resolver.handleChunk(chunk3);
         expect(onResponse.mock.calls[0][0]).toMatchSnapshot();
     });
+
+    it('should work when not applying to previous', function() {
+        const onResponse = jest.fn();
+        const resolver = new PatchResolver({
+            onResponse,
+            applyToPrevious: false,
+        });
+
+        const chunk2a = chunk2.substring(0, 35);
+        const chunk2b = chunk2.substring(35);
+
+        resolver.handleChunk(chunk1 + chunk2a);
+        expect(onResponse.mock.calls[0][0]).toMatchSnapshot();
+        onResponse.mockClear();
+        resolver.handleChunk(chunk2b);
+        expect(onResponse.mock.calls[0][0]).toMatchSnapshot();
+    });
 });

--- a/src/__test__/__snapshots__/PatchResolver.spec.js.snap
+++ b/src/__test__/__snapshots__/PatchResolver.spec.js.snap
@@ -44,6 +44,7 @@ Object {
       "message": "Not So Bad Error",
     },
   ],
+  "extensions": undefined,
 }
 `;
 
@@ -75,6 +76,7 @@ Object {
       "message": "Not So Bad Error",
     },
   ],
+  "extensions": undefined,
 }
 `;
 
@@ -138,6 +140,7 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;
 
@@ -176,6 +179,7 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;
 
@@ -214,6 +218,7 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;
 
@@ -250,6 +255,7 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;
 
@@ -313,6 +319,7 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;
 
@@ -349,6 +356,7 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;
 
@@ -387,6 +395,7 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;
 
@@ -450,6 +459,7 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;
 
@@ -488,5 +498,6 @@ Object {
     },
   },
   "errors": undefined,
+  "extensions": undefined,
 }
 `;

--- a/src/__test__/__snapshots__/PatchResolver.spec.js.snap
+++ b/src/__test__/__snapshots__/PatchResolver.spec.js.snap
@@ -501,3 +501,48 @@ Object {
   "extensions": undefined,
 }
 `;
+
+exports[`PathResolver should work when not applying to previous 1`] = `
+Object {
+  "data": Object {
+    "viewer": Object {
+      "currencies": null,
+      "user": Object {
+        "items": Object {
+          "edges": Array [
+            Object {
+              "node": Object {
+                "isFavorite": null,
+              },
+            },
+            Object {
+              "node": Object {
+                "isFavorite": null,
+              },
+            },
+          ],
+        },
+        "profile": null,
+      },
+    },
+  },
+}
+`;
+
+exports[`PathResolver should work when not applying to previous 2`] = `
+Object {
+  "data": Array [
+    "USD",
+    "GBP",
+    "EUR",
+    "CAD",
+    "AUD",
+    "CHF",
+    "😂",
+  ],
+  "path": Array [
+    "viewer",
+    "currencies",
+  ],
+}
+`;

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,6 +1,6 @@
 import { PatchResolver } from './PatchResolver';
 
-export function fetchImpl(url, { method, headers, credentials, body, onNext, onError, onComplete }) {
+export function fetchImpl(url, { method, headers, credentials, body, onNext, onError, onComplete, applyToPrevious }) {
     return fetch(url, { method, headers, body, credentials }).then(response => {
         // @defer uses multipart responses to stream patches over HTTP
         if (
@@ -12,7 +12,7 @@ export function fetchImpl(url, { method, headers, credentials, body, onNext, onE
             // For the majority of browsers with support for ReadableStream and TextDecoder
             const reader = response.body.getReader();
             const textDecoder = new TextDecoder();
-            const patchResolver = new PatchResolver({ onResponse: r => onNext(r) });
+            const patchResolver = new PatchResolver({ onResponse: r => onNext(r), applyToPrevious });
             return reader.read().then(function sendNext({ value, done }) {
                 if (!done) {
                     let plaintext;

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -11,13 +11,13 @@ function supportsXhrResponseType(type) {
     return false;
 }
 
-export function xhrImpl(url, { method, headers, credentials, body, onNext, onError, onComplete }) {
+export function xhrImpl(url, { method, headers, credentials, body, onNext, onError, onComplete, applyToPrevious }) {
     const xhr = new XMLHttpRequest();
     xhr.withCredentials = credentials === 'include'; // follow behavior of fetch credentials param https://github.com/github/fetch#sending-cookies
     let index = 0;
     let isDeferred = false;
 
-    const patchResolver = new PatchResolver({ onResponse: r => onNext(r) });
+    const patchResolver = new PatchResolver({ onResponse: r => onNext(r), applyToPrevious });
 
     function onReadyStateChange() {
         // The request failed, do nothing and let the error event fire


### PR DESCRIPTION
Adds `applyToPrevious` option, when set to `false` will return individual patches, instead of incremental responses.