### PR TITLE
feat: remove the need for content-length

### DIFF
--- a/src/PatchResolver.js
+++ b/src/PatchResolver.js
@@ -3,13 +3,14 @@ import { parseMultipartHttp } from './parseMultipartHttp';
 export function PatchResolver({ onResponse, boundary }) {
     this.boundary = boundary || '-';
     this.onResponse = onResponse;
-    this.processedChunks = 0;
     this.chunkBuffer = '';
+    this.isPreamble = true;
 }
 
 PatchResolver.prototype.handleChunk = function (data) {
     this.chunkBuffer += data;
-    const { newBuffer, parts } = parseMultipartHttp(this.chunkBuffer, this.boundary);
+    const { newBuffer, parts, isPreamble } = parseMultipartHttp(this.chunkBuffer, this.boundary, [], this.isPreamble);
+    this.isPreamble = isPreamble;
     this.chunkBuffer = newBuffer;
     if (parts.length) {
         this.onResponse(parts);

--- a/src/__test__/PatchResolver.spec.js
+++ b/src/__test__/PatchResolver.spec.js
@@ -63,6 +63,8 @@ describe('PathResolver', function () {
 
                 resolver.handleChunk(`\r\n--${boundary}\r\n`);
 
+                expect(onResponse).not.toHaveBeenCalled();
+
                 resolver.handleChunk(chunk1);
                 expect(onResponse.mock.calls[0][0]).toEqual([chunk1Data]);
 
@@ -91,6 +93,8 @@ describe('PathResolver', function () {
                 const chunk1c = chunk1.substr(35 + 80);
 
                 resolver.handleChunk(`\r\n--${boundary}\r\n`);
+
+                expect(onResponse).not.toHaveBeenCalled();
 
                 resolver.handleChunk(chunk1a);
                 expect(onResponse).not.toHaveBeenCalled();
@@ -130,6 +134,8 @@ describe('PathResolver', function () {
 
                 resolver.handleChunk(`\r\n--${boundary}\r\n`);
 
+                expect(onResponse).not.toHaveBeenCalled();
+
                 resolver.handleChunk(chunk1 + chunk2);
                 expect(onResponse.mock.calls[0][0]).toEqual([chunk1Data, chunk2Data]);
             });
@@ -141,11 +147,21 @@ describe('PathResolver', function () {
                     boundary,
                 });
 
+                const boundaryChunk = `\r\n--${boundary}\r\n`;
+
                 const chunk3a = chunk3.substr(0, 11);
                 const chunk3b = chunk3.substr(11, 20);
                 const chunk3c = chunk3.substr(11 + 20);
 
-                resolver.handleChunk(`\r\n--${boundary}\r\n`);
+                const boundary1 = boundaryChunk.substr(0, 5);
+                const boundary2 = boundaryChunk.substr(5, 7);
+                const boundary3 = boundaryChunk.substr(5 + 7);
+
+                resolver.handleChunk(boundary1);
+                resolver.handleChunk(boundary2);
+                resolver.handleChunk(boundary3);
+
+                expect(onResponse).not.toHaveBeenCalled();
 
                 resolver.handleChunk(chunk1 + chunk2 + chunk3a);
                 expect(onResponse.mock.calls[0][0]).toEqual([chunk1Data, chunk2Data]);
@@ -165,6 +181,8 @@ describe('PathResolver', function () {
                 });
 
                 resolver.handleChunk(`\r\n--${boundary}\r\n`);
+
+                expect(onResponse).not.toHaveBeenCalled();
 
                 const chunk2a = chunk2.substring(0, 35);
                 const chunk2b = chunk2.substring(35);

--- a/src/__test__/PatchResolver.spec.js
+++ b/src/__test__/PatchResolver.spec.js
@@ -6,16 +6,12 @@ global.TextDecoder = TextDecoder;
 
 function getMultiPartResponse(data, boundary) {
     const json = JSON.stringify(data);
-    const chunk = Buffer.from(json, 'utf8');
 
     return [
-        '',
-        `--${boundary}`,
         'Content-Type: application/json',
-        `Content-Length: ${String(chunk.length)}`,
         '',
         json,
-        '',
+        `--${boundary}\r\n`,
     ].join('\r\n');
 }
 
@@ -65,6 +61,8 @@ describe('PathResolver', function () {
                     boundary,
                 });
 
+                resolver.handleChunk(`\r\n--${boundary}\r\n`);
+
                 resolver.handleChunk(chunk1);
                 expect(onResponse.mock.calls[0][0]).toEqual([chunk1Data]);
 
@@ -88,13 +86,11 @@ describe('PathResolver', function () {
                     boundary,
                 });
 
-                if (boundary === 'gc0p4Jq0M2Yt08jU534c0p') {
-                    debugger;
-                }
-
                 const chunk1a = chunk1.substr(0, 35);
                 const chunk1b = chunk1.substr(35, 80);
                 const chunk1c = chunk1.substr(35 + 80);
+
+                resolver.handleChunk(`\r\n--${boundary}\r\n`);
 
                 resolver.handleChunk(chunk1a);
                 expect(onResponse).not.toHaveBeenCalled();
@@ -132,6 +128,8 @@ describe('PathResolver', function () {
                     boundary,
                 });
 
+                resolver.handleChunk(`\r\n--${boundary}\r\n`);
+
                 resolver.handleChunk(chunk1 + chunk2);
                 expect(onResponse.mock.calls[0][0]).toEqual([chunk1Data, chunk2Data]);
             });
@@ -146,6 +144,8 @@ describe('PathResolver', function () {
                 const chunk3a = chunk3.substr(0, 11);
                 const chunk3b = chunk3.substr(11, 20);
                 const chunk3c = chunk3.substr(11 + 20);
+
+                resolver.handleChunk(`\r\n--${boundary}\r\n`);
 
                 resolver.handleChunk(chunk1 + chunk2 + chunk3a);
                 expect(onResponse.mock.calls[0][0]).toEqual([chunk1Data, chunk2Data]);
@@ -163,6 +163,8 @@ describe('PathResolver', function () {
                     onResponse,
                     boundary,
                 });
+
+                resolver.handleChunk(`\r\n--${boundary}\r\n`);
 
                 const chunk2a = chunk2.substring(0, 35);
                 const chunk2b = chunk2.substring(35);

--- a/src/parseMultipartHttp.js
+++ b/src/parseMultipartHttp.js
@@ -2,75 +2,51 @@ function getDelimiter(boundary) {
     return `\r\n--${boundary}\r\n`;
 }
 
-function getFinalDelimiter(boundary) {
-    return `\r\n--${boundary}--\r\n`;
-}
-
 function splitWithRest(string, delim) {
     const index = string.indexOf(delim);
     if (index < 0) {
-        return [string];
+        return [undefined, string];
     }
     return [string.substring(0, index), string.substring(index + delim.length)];
 }
 
-export function parseMultipartHttp(buffer, boundary, previousParts = []) {
-    const delimeter = getDelimiter(boundary);
-    let [, rest] = splitWithRest(buffer, delimeter);
-    if (!(rest && rest.length)) {
-        // we did not finish receiving the initial delimeter
+export function parseMultipartHttp(buffer, boundary, previousParts = [], isPreamble = true) {
+    const delimiter = getDelimiter(boundary);
+
+    const [region, next] = splitWithRest(buffer, delimiter);
+
+    if (region !== undefined && (region.length || region.trim() === '') && isPreamble) {
+        if (next && next.length) {
+            // if we have stuff after the boundary; and we're in preamble—we recurse
+            return parseMultipartHttp(next, boundary, previousParts, false);
+        } else {
+            return { newBuffer: '', parts: previousParts, isPreamble: false };
+        }
+    }
+
+    if (!(region && region.length)) {
+        // we need more things
         return {
             newBuffer: buffer,
             parts: previousParts,
-        };
-    }
-    const parts = splitWithRest(rest, '\r\n\r\n');
-    const headers = parts[0];
-    rest = parts[1];
-
-    if (!(rest && rest.length)) {
-        // we did not finish receiving the headers
-        return {
-            newBuffer: buffer,
-            parts: previousParts,
+            isPreamble
         };
     }
 
-    const headersArr = headers.split('\r\n');
-    const contentLengthHeader = headersArr.find(
-        (headerLine) => headerLine.toLowerCase().indexOf('content-length:') >= 0
-    );
-    if (contentLengthHeader === undefined) {
-        throw new Error('Invalid MultiPart Response, no content-length header');
-    }
-    const contentLengthArr = contentLengthHeader.split(':');
-    let contentLength;
-    if (contentLengthArr.length === 2 && !isNaN(parseInt(contentLengthArr[1]))) {
-        contentLength = parseInt(contentLengthArr[1]);
-    } else {
-        throw new Error('Invalid MultiPart Response, could not parse content-length');
-    }
+    let [_headers, body] = splitWithRest(region, '\r\n\r\n');
 
-    // Strip out the final delimiter
-    const finalDelimeter = getFinalDelimiter(boundary);
-    rest = rest.replace(finalDelimeter, '');
-    const uint = new TextEncoder().encode(rest);
+    // remove trailing boundary things
+    body = body
+        .replace(delimiter + '\r\n', '')
+        .replace(delimiter + '--\r\n', '');
 
-    if (uint.length < contentLength) {
-        // still waiting for more body to be sent;
-        return {
-            newBuffer: buffer,
-            parts: previousParts,
-        };
+    const payload = JSON.parse(body);
+    const parts = [...previousParts, payload];
+
+    if (next && next.length) {
+        // we have more parts
+        return parseMultipartHttp(next, boundary, parts, isPreamble);
     }
 
-    const body = new TextDecoder().decode(uint.subarray(0, contentLength));
-    const nextBuffer = new TextDecoder().decode(uint.subarray(contentLength));
-    const part = JSON.parse(body);
-    const newParts = [...previousParts, part];
-
-    if (nextBuffer.length) {
-        return parseMultipartHttp(nextBuffer, boundary, newParts);
-    }
-    return { parts: newParts, newBuffer: '' };
+    return { parts, newBuffer: '', isPreamble };
 }


### PR DESCRIPTION
From the https://github.com/graphql/graphql-over-http/pull/152 we no longer need content-length things. This PR aims to parse till a boundary, and yield then.

cc @robrichard 