### PR TITLE
Make sure all fetch options are passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ function fetchQuery(operation, variables) {
 
 The `credentials` param is passed to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters). For XHR requests, [`XMLHttpRequest.withCredentials`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) is mapped to true when `credentials: 'include'`.
 
+#### Handling additional request settings
+
+When `fetch` is not available requests are sent through XHR, which supports standard `method`, `headers`, `credentials` and `body` settings; as seen in the code example above. 
+When requests are sent through `fetch` we can also set, in addition to the properties already mentioned, all the [options supported by fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options).
+
 ## Browser Support
 
 Tested in the latest Chrome, Firefox, Safari, Edge, and Internet Explorer 11. Requires a polyfill for TextEncoder/Decoder. Since only utf-8 encoding is required, it's recommended to use [text-encoding-utf-8](https://www.npmjs.com/package/text-encoding-utf-8) to minimize impact on bundle size.

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,11 +1,8 @@
 import { PatchResolver } from './PatchResolver';
 import { getBoundary } from './getBoundary';
 
-export function fetchImpl(
-    url,
-    { method, headers, credentials, body, onNext, onError, onComplete }
-) {
-    return fetch(url, { method, headers, body, credentials })
+export function fetchImpl(url, { onNext, onComplete, onError, ...fetchOptions }) {
+    return fetch(url, fetchOptions)
         .then((response) => {
             const contentType = (!!response.headers && response.headers.get('Content-Type')) || '';
             // @defer uses multipart responses to stream patches over HTTP


### PR DESCRIPTION
Currently, the fetch implementation has a whitelist approach to pass options to fetch.
Specifically, only `method`, `headers`, `credentials`, and `body` are passed to the underlying fetch function.

However, `fetch` supports many additional options, such as `mode`, `cache`, `redirect`, `referrer`, `referrerPolicy`, `integrity`, `keepalive`, and `signal`.

Developers might need to specify any of those valid additional options and so these must be passed to fetch.

For simplicity in this PR, I am removing the whitelist approach and I am extracting the properties needed by `fetch-multipart` (which are just `onNext`, `onComplete`, and `onError`) and passing all remaining properties to fetch assuming these must be valid fetch options.

This approach shifts responsibility to the developers, ultimately they have the ability to specify any fetch option they might need and so they must be responsible to use valid options as per fetch specs.