### PR TITLE
fix: don't require trailing line break on terminal boundary

### DIFF
--- a/src/parseMultipartHttp.js
+++ b/src/parseMultipartHttp.js
@@ -3,7 +3,7 @@ function getDelimiter(boundary) {
 }
 
 function getClosingDelimiter(boundary) {
-    return `\r\n--${boundary}--\r\n`;
+    return `\r\n--${boundary}--`;
 }
 
 function splitWithRest(string, delim) {


### PR DESCRIPTION
Closes https://github.com/relay-tools/fetch-multipart-graphql/issues/52