### PR TITLE
Call onError if HTTP status code >= 300 and not multipart mixed response.

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -35,6 +35,11 @@ export function fetchImpl(url, { onNext, onComplete, onError, ...fetchOptions })
                         onComplete();
                     }
                 });
+            } else if (response.status >= 300) {
+                const error = new Error(`HTTP ${response.status}: ${response.statusText}`);
+                error.response = response;
+                error.statusCode = response.status;
+                onError(error);
             } else {
                 return response.json().then((json) => {
                     onNext([json], { responseHeaders: response.headers });


### PR DESCRIPTION
This enables middleware in https://github.com/relay-tools/react-relay-network-modern, for example the `authMiddleware` to properly switch on status code == 401.